### PR TITLE
fix: update docker-compose.yml version from v1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   writer:
     image: givery/marine:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3.9"
 services:
   writer:
     image: givery/marine:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-writer:
-  image: givery/marine:latest
-  ports:
-    - "39000:9000"
-  volumes:
-    - $PWD/contents:/opt/docker/contents
+version: "3.9"
+services:
+  writer:
+    image: givery/marine:latest
+    ports:
+      - "39000:9000"
+    volumes:
+      - $PWD/contents:/opt/docker/contents


### PR DESCRIPTION
resolves #28
V2以降で推奨されるフォーマットに変えようと思います。これによって古い一部のdocker-composeが動作しなくなる可能性があるため、事前に確認されることが望ましいです。