### PR TITLE
docker-compose.yml for Internal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /contents/*
 !/contents/sample
+/orcalogs/*.jsonl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   writer:
     image: givery/marine:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,22 @@
 version: "3.9"
 services:
   writer:
-    image: givery/marine:latest
+    image: givery/marine:internal
     ports:
       - "39000:9000"
     volumes:
-      - $PWD/contents:/opt/docker/contents
+      - ./contents:/opt/docker/contents
+      - ./orcalogs:/opt/docker/orcalogs
+    # environment:
+    #   READER_JS_PATH: http://localhost:3000/assets/reader.js
+    #   READER_CSS_PATH: http://localhost:3000/assets/reader.css
+    #   CODING_JS_PATH: http://localhost:3000/assets/coding.js
+    #   CODING_CSS_PATH: http://localhost:3000/assets/coding.css
+    #   AI_JS_PATH: http://localhost:3000/assets/ai.js
+    #   AI_CSS_PATH: http://localhost:3000/assets/ai.css
+    #   WEB_JS_PATH: http://localhost:3000/assets/web.js
+    #   WEB_CSS_PATH: http://localhost:3000/assets/web.css
+    #   MARKDOWN_EDITOR_JS_PATH: http://localhost:3000/assets/markdown-editor.js
+    #   MARKDOWN_EDITOR_CSS_PATH: http://localhost:3000/assets/markdown-editor.css
+    #   MARKDOWN_HELPER_JS_PATH: http://localhost:3000/assets/markdown-helper.js
+    #   MARKDOWN_HELPER_CSS_PATH: http://localhost:3000/assets/markdown-helper.css

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3.9"
 services:
   writer:
     image: givery/marine:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-writer:
-  image: givery/marine:latest
-  ports:
-    - "39000:9000"
-  volumes:
-    - $PWD/contents:/opt/docker/contents
+version: "3.9"
+services:
+  writer:
+    image: givery/marine:latest
+    ports:
+      - "39000:9000"
+    volumes:
+      - $PWD/contents:/opt/docker/contents


### PR DESCRIPTION
internalリリース向けのdocker-compose.ymlです。
masterとの違いは

- imageNameが `givery/marine:latest`ではなく `givery/marine:internal`となっている
- `orcalogs`ディレクトリがvolumeとしてコンテナにマップされている
  - このディレクトリには5.3.2で機能追加されたOrcaRecordingログが保存されます。

コメントアウトされているenvironmentの定義はEditor開発者向けの設定なので無視して良いです。
