### PR TITLE
Fix Additional property writer is not allowed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-writer:
-  image: givery/marine:latest
-  ports:
-    - "39000:9000"
-  volumes:
-    - $PWD/contents:/opt/docker/contents
+version: "2"
+services:
+  writer:
+    image: givery/marine:latest
+    ports:
+      - "39000:9000"
+    volumes:
+      - $PWD/contents:/opt/docker/contents


### PR DESCRIPTION
@shunjikonishi review me.

久しぶりにMarine立ち上げたらエラーが出ていました。

> docker compose で「Additional property {property} is not allowed」エラーが出る

- https://qiita.com/mida12251141/items/2e07cb332e436e56fcc9